### PR TITLE
feat: Keyboard navigation added for periodic table

### DIFF
--- a/components/periodic-table/project/data_page/DataPage.vue
+++ b/components/periodic-table/project/data_page/DataPage.vue
@@ -398,9 +398,9 @@ export default {
     // フォーカスされた元素が変更されたら、データページを更新する
     focusedAtomicNumber(newValue) {
       if (this.isDataPageActive && newValue >= 1 && newValue <= 118) {
-        this.openDataPage(newValue);
+        this.openDataPage(newValue)
       }
-    }
+    },
   },
 
   methods: {

--- a/components/periodic-table/project/data_page/DataPage.vue
+++ b/components/periodic-table/project/data_page/DataPage.vue
@@ -411,16 +411,6 @@ export default {
       closeDataPage: 'element/closeDataPage',
       showToast: 'toast/showToast',
     }),
-    handleKeyDown(event) {
-      if (!this.isDataPageActive) return;
-      
-      // ESC で詳細を閉じる
-      if (event.key.toLowerCase() === 'escape') {
-        this.closeDataPage();
-        event.preventDefault();
-        event.stopPropagation();
-      }
-    },
     /**
      * オーバーレイ表示時、データページのスクロール量を0にする
      * @param {object} el - オーバーレイの要素
@@ -490,14 +480,6 @@ export default {
         this.showToast(failureMessage)
       }
     },
-  },
-  mounted() {
-    // ESC キーハンドラーを追加
-    window.addEventListener('keydown', this.handleKeyDown);
-  },
-  beforeDestroy() {
-    // ESC キーハンドラーを削除
-    window.removeEventListener('keydown', this.handleKeyDown);
   },
 }
 </script>

--- a/components/periodic-table/project/data_page/DataPage.vue
+++ b/components/periodic-table/project/data_page/DataPage.vue
@@ -402,10 +402,33 @@ export default {
       showToast: 'toast/showToast',
     }),
     handleKeyDown(event) {  
-      if (event.key === 'Escape' && this.isDataPageActive) {  
+      if (!this.isDataPageActive) return;
+      // 次の元素、前の元素のショートカット
+      const key = event.key.toLowerCase();
+
+      // 次の元素
+      if (
+        key === 'f' || 
+        key === 'n' || 
+        key === 'arrowright'
+      ) {
+        this.switchDataPage('next');
+        event.preventDefault();
+      }
+      // 前の元素
+      else if (
+        key === 'p' || 
+        key === 'b' || 
+        key === 'arrowleft'
+      ) {
+        this.switchDataPage('prev');
+        event.preventDefault();
+      }
+      // ESC で詳細を閉じる
+      else if (key === 'escape') {  
         this.closeDataPage();  
       }  
-    },  
+    },
     /**
      * オーバーレイ表示時、データページのスクロール量を0にする
      * @param {object} el - オーバーレイの要素

--- a/components/periodic-table/project/data_page/DataPage.vue
+++ b/components/periodic-table/project/data_page/DataPage.vue
@@ -342,6 +342,7 @@ export default {
       elementList: 'element/elementList',
       currentDataPage: 'element/currentDataPage',
       isDataPageActive: 'element/isDataPageActive',
+      focusedAtomicNumber: 'element/focusedAtomicNumber',
     }),
     /**
      * 現在のデータページのページ遷移ボタンの表示内容
@@ -393,6 +394,15 @@ export default {
     },
   },
 
+  watch: {
+    // フォーカスされた元素が変更されたら、データページを更新する
+    focusedAtomicNumber(newValue) {
+      if (this.isDataPageActive && newValue >= 1 && newValue <= 118) {
+        this.openDataPage(newValue);
+      }
+    }
+  },
+
   methods: {
     ...mapMutations(['updateIsBodyScrollLocked']),
     ...mapActions({
@@ -403,30 +413,12 @@ export default {
     }),
     handleKeyDown(event) {
       if (!this.isDataPageActive) return;
-      // 次の元素、前の元素のショートカット
-      const key = event.key.toLowerCase();
-
-      // 次の元素
-      if (
-        key === 'f' ||
-        key === 'n' ||
-        key === 'arrowright'
-      ) {
-        this.switchDataPage('next');
-        event.preventDefault();
-      }
-      // 前の元素
-      else if (
-        key === 'p' ||
-        key === 'b' ||
-        key === 'arrowleft'
-      ) {
-        this.switchDataPage('prev');
-        event.preventDefault();
-      }
+      
       // ESC で詳細を閉じる
-      else if (key === 'escape') {
+      if (event.key.toLowerCase() === 'escape') {
         this.closeDataPage();
+        event.preventDefault();
+        event.stopPropagation();
       }
     },
     /**
@@ -500,9 +492,11 @@ export default {
     },
   },
   mounted() {
+    // ESC キーハンドラーを追加
     window.addEventListener('keydown', this.handleKeyDown);
   },
   beforeDestroy() {
+    // ESC キーハンドラーを削除
     window.removeEventListener('keydown', this.handleKeyDown);
   },
 }

--- a/components/periodic-table/project/data_page/DataPage.vue
+++ b/components/periodic-table/project/data_page/DataPage.vue
@@ -401,15 +401,15 @@ export default {
       closeDataPage: 'element/closeDataPage',
       showToast: 'toast/showToast',
     }),
-    handleKeyDown(event) {  
+    handleKeyDown(event) {
       if (!this.isDataPageActive) return;
       // 次の元素、前の元素のショートカット
       const key = event.key.toLowerCase();
 
       // 次の元素
       if (
-        key === 'f' || 
-        key === 'n' || 
+        key === 'f' ||
+        key === 'n' ||
         key === 'arrowright'
       ) {
         this.switchDataPage('next');
@@ -417,17 +417,17 @@ export default {
       }
       // 前の元素
       else if (
-        key === 'p' || 
-        key === 'b' || 
+        key === 'p' ||
+        key === 'b' ||
         key === 'arrowleft'
       ) {
         this.switchDataPage('prev');
         event.preventDefault();
       }
       // ESC で詳細を閉じる
-      else if (key === 'escape') {  
-        this.closeDataPage();  
-      }  
+      else if (key === 'escape') {
+        this.closeDataPage();
+      }
     },
     /**
      * オーバーレイ表示時、データページのスクロール量を0にする

--- a/components/periodic-table/project/periodic_table/PeriodicTable.vue
+++ b/components/periodic-table/project/periodic_table/PeriodicTable.vue
@@ -1,5 +1,6 @@
 <template>
   <section
+    ref="periodicTableSection"
     class="periodic-table"
     :class="{
       'is-overflow-scroll': isPeriodicTableOverflow,
@@ -8,10 +9,9 @@
     :style="{
       height: periodicTableRect.height * periodicTableScale + 'px',
     }"
+    tabindex="0"
     @keydown="handleKeyDown"
     @click="handleBackgroundClick"
-    tabindex="0"
-    ref="periodicTableSection"
   >
     <div
       ref="periodicTable"
@@ -63,19 +63,19 @@
       <button
         v-for="(element, elementIndex) in elementList"
         :key="'cell-' + elementIndex"
+        :ref="'element-' + element.atomicNumber"
         type="button"
         class="periodic-table__cell-wrapper"
         :class="[
           'periodic-table__cell-wrapper--cell-' + element.elementSymbol,
           {
             'is-active': elementStatusList[elementIndex].isDataPageActive,
-            'is-focused': focusedAtomicNumber === element.atomicNumber
+            'is-focused': focusedAtomicNumber === element.atomicNumber,
           },
         ]"
+        tabindex="-1"
         @click="openDataPage(element.atomicNumber)"
         @mousemove="handleElementHover(element.atomicNumber)"
-        :ref="'element-' + element.atomicNumber"
-        tabindex="-1"
       >
         <div
           class="periodic-table__cell"
@@ -138,7 +138,7 @@ export default {
         16: [8, 16, 34, 52, 84, 116],
         17: [9, 17, 35, 53, 85, 117],
         18: [2, 10, 18, 36, 54, 86, 118],
-      }
+      },
     }
   },
 
@@ -178,15 +178,15 @@ export default {
 
     // 周期表にフォーカスする
     this.$nextTick(() => {
-      this.$refs.periodicTableSection.focus();
-    });
+      this.$refs.periodicTableSection.focus()
+    })
 
     // キーボードイベントリスナーを追加
-    window.addEventListener('keydown', this.handleKeyDown);
+    window.addEventListener('keydown', this.handleKeyDown)
   },
 
   beforeDestroy() {
-    window.removeEventListener('keydown', this.handleKeyDown);
+    window.removeEventListener('keydown', this.handleKeyDown)
   },
 
   methods: {
@@ -202,8 +202,10 @@ export default {
      * 原子番号がランタノイドまたはアクチノイドかを判定する
      */
     isLanthanoidOrActinoid(atomicNumber) {
-      return (atomicNumber >= 57 && atomicNumber <= 71) ||
-             (atomicNumber >= 89 && atomicNumber <= 103);
+      return (
+        (atomicNumber >= 57 && atomicNumber <= 71) ||
+        (atomicNumber >= 89 && atomicNumber <= 103)
+      )
     },
     /**
      * 画面幅が周期表の幅を超過しているかを示すハンドラ
@@ -231,28 +233,30 @@ export default {
      * カーソルがホバーしているセルにフォーカスする
      */
     handleElementHover(atomicNumber) {
-      this.updateFocusedAtomicNumber(atomicNumber);
+      this.updateFocusedAtomicNumber(atomicNumber)
     },
     /**
      * ↑ ↓ で同族の前・次の元素に行く
      */
     findNextInGroup(direction) {
-      const currentElement = this.elementList.find(e => e.atomicNumber === this.focusedAtomicNumber);
-      if (!currentElement) return this.focusedAtomicNumber;
+      const currentElement = this.elementList.find(
+        (e) => e.atomicNumber === this.focusedAtomicNumber
+      )
+      if (!currentElement) return this.focusedAtomicNumber
 
-      const groupElements = this.groupNavigation[currentElement.group];
-      if (!groupElements) return this.focusedAtomicNumber;
+      const groupElements = this.groupNavigation[currentElement.group]
+      if (!groupElements) return this.focusedAtomicNumber
 
-      const currentIndex = groupElements.indexOf(this.focusedAtomicNumber);
-      if (currentIndex === -1) return this.focusedAtomicNumber;
+      const currentIndex = groupElements.indexOf(this.focusedAtomicNumber)
+      if (currentIndex === -1) return this.focusedAtomicNumber
 
-      const nextIndex = direction === 'up' ? currentIndex - 1 : currentIndex + 1;
+      const nextIndex = direction === 'up' ? currentIndex - 1 : currentIndex + 1
 
       if (nextIndex >= 0 && nextIndex < groupElements.length) {
-        return groupElements[nextIndex];
+        return groupElements[nextIndex]
       }
 
-      return this.focusedAtomicNumber;
+      return this.focusedAtomicNumber
     },
     /**
      * クリック対象がセクション自体である場合、フォーカスを解除する
@@ -260,10 +264,10 @@ export default {
      */
     handleBackgroundClick(event) {
       if (
-        event.target === this.$refs.periodicTableSection || 
+        event.target === this.$refs.periodicTableSection ||
         event.target === this.$refs.periodicTable
       ) {
-        this.updateFocusedAtomicNumber(null);
+        this.updateFocusedAtomicNumber(null)
       }
     },
     /**
@@ -273,90 +277,90 @@ export default {
      * ESC キーでフォーカスを解除する
      */
     handleKeyDown(event) {
-      const key = event.key;
-      let nextAtomicNumber = this.focusedAtomicNumber;
+      const key = event.key
+      let nextAtomicNumber = this.focusedAtomicNumber
 
       // ESC キーの処理
       if (key === 'Escape') {
         if (this.isDataPageActive) {
           // DataPage がアクティブの場合は閉じるだけでフォーカスは維持する
-          this.closeDataPage();
+          this.closeDataPage()
         } else {
           // DataPage がアクティブでない場合はフォーカスを解除する
-          this.updateFocusedAtomicNumber(null);
+          this.updateFocusedAtomicNumber(null)
         }
-        event.preventDefault();
-        event.stopPropagation();
-        return;
+        event.preventDefault()
+        event.stopPropagation()
+        return
       }
 
       // フォーカスがない状態で方向キーが押された場合
       if (this.focusedAtomicNumber === null) {
         if (['ArrowRight', 'ArrowDown'].includes(key)) {
           // → または ↓ で水素（原子番号 1）にフォーカスする
-          this.updateFocusedAtomicNumber(1);
-          event.preventDefault();
-          event.stopPropagation();
-          return;
+          this.updateFocusedAtomicNumber(1)
+          event.preventDefault()
+          event.stopPropagation()
+          return
         } else if (['ArrowLeft', 'ArrowUp'].includes(key)) {
           // ← または ↑ 矢印でオガネソン（原子番号 118）にフォーカスする
-          this.updateFocusedAtomicNumber(118);
-          event.preventDefault();
-          event.stopPropagation();
-          return;
+          this.updateFocusedAtomicNumber(118)
+          event.preventDefault()
+          event.stopPropagation()
+          return
         }
-        return; // フォーカスがない場合は他のキーは処理しない
+        return // フォーカスがない場合は他のキーは処理しない
       }
 
       switch (key) {
         case 'ArrowRight':
-          if (nextAtomicNumber < 118) nextAtomicNumber++;
-          event.preventDefault();
-          event.stopPropagation();
-          break;
+          if (nextAtomicNumber < 118) nextAtomicNumber++
+          event.preventDefault()
+          event.stopPropagation()
+          break
         case 'ArrowLeft':
-          if (nextAtomicNumber > 1) nextAtomicNumber--;
-          event.preventDefault();
-          event.stopPropagation();
-          break;
+          if (nextAtomicNumber > 1) nextAtomicNumber--
+          event.preventDefault()
+          event.stopPropagation()
+          break
         case 'ArrowUp': {
           // ランタノイドやアクチノイドの場合は ↑ でも ← でも前の元素（原子番号 -1）に行く
           if (this.isLanthanoidOrActinoid(nextAtomicNumber)) {
-            nextAtomicNumber--;
+            nextAtomicNumber--
           } else {
-            nextAtomicNumber = this.findNextInGroup('up');
+            nextAtomicNumber = this.findNextInGroup('up')
           }
-          event.preventDefault();
-          event.stopPropagation();
-          break;
+          event.preventDefault()
+          event.stopPropagation()
+          break
         }
         case 'ArrowDown': {
           // ランタノイドやアクチノイドの場合は ↓ でも → でも次の元素（原子番号 +1）に行く
           if (this.isLanthanoidOrActinoid(nextAtomicNumber)) {
-            nextAtomicNumber++;
+            nextAtomicNumber++
           } else {
-            nextAtomicNumber = this.findNextInGroup('down');
+            nextAtomicNumber = this.findNextInGroup('down')
           }
-          event.preventDefault();
-          event.stopPropagation();
-          break;
+          event.preventDefault()
+          event.stopPropagation()
+          break
         }
         case ' ':
         case 'Enter':
           if (this.isDataPageActive) {
             // DataPage がアクティブの場合は閉じる
-            this.closeDataPage();
+            this.closeDataPage()
           } else {
             // DataPage がアクティブでない場合は開く
-            this.openDataPage(this.focusedAtomicNumber);
+            this.openDataPage(this.focusedAtomicNumber)
           }
-          event.preventDefault();
-          event.stopPropagation();
-          return;
+          event.preventDefault()
+          event.stopPropagation()
+          return
       }
 
       if (nextAtomicNumber !== this.focusedAtomicNumber) {
-        this.updateFocusedAtomicNumber(nextAtomicNumber);
+        this.updateFocusedAtomicNumber(nextAtomicNumber)
       }
     },
   },
@@ -511,11 +515,15 @@ $animeNameList: 'intoAN' 'intoES' 'intoJA' 'intoEN' 'intoSC' 'intoTW' 'intoHK';
       transform: translate3d(0, -5px, 10px) scale(1.2) rotateY(0);
       @include g.boxShadow(4);
       background: pt.$colorWhite;
-      transition-property: transform, background-color, color, border-color, box-shadow;
+      transition-property: transform, background-color, color, border-color,
+        box-shadow;
       transition-duration: 0.2s;
 
       @each $category in pt.$categoryList {
-        $categoryColor: nth(pt.$categoryColorList, index(pt.$categoryList, $category));
+        $categoryColor: nth(
+          pt.$categoryColorList,
+          index(pt.$categoryList, $category)
+        );
         &.periodic-table__cell--category-#{$category} {
           @if $category == h {
             border-color: pt.$colorHydrogenBlack;

--- a/components/periodic-table/project/periodic_table/PeriodicTable.vue
+++ b/components/periodic-table/project/periodic_table/PeriodicTable.vue
@@ -118,7 +118,7 @@ export default {
       /** 周期表の幅に対して作成したMediaQueryList */
       periodicTableMQL: null,
       /** フォーカスにある元素の原子番号 */
-      focusedAtomicNumber: 1, // Start with Hydrogen
+      focusedAtomicNumber: null,
       /** ↑↓で移動する時の原子番号のマップ */
       groupNavigation: {
         1: [1, 3, 11, 19, 37, 55, 87],
@@ -149,6 +149,7 @@ export default {
       elementList: 'element/elementList',
       elementStatusList: 'element/elementStatusList',
       currentLang: 'lang/currentLang',
+      isDataPageActive: 'element/isDataPageActive',
     }),
   },
 
@@ -175,7 +176,7 @@ export default {
     this.createMediaQuery()
     this.checkPeriodicTableOverflow()
 
-    // 最初のフォーカスを水素にする
+    // 周期表にフォーカスする
     this.$nextTick(() => {
       this.$refs.periodicTableSection.focus();
     });
@@ -246,11 +247,36 @@ export default {
 
     /**
      * キーボード操作
-     * 上下左右で移動、スペースキー・リターンキーで詳細を開ける
+     * 上下左右でフォーカスを移動、フォーカスがない場合は新たなフォーカスを指定
+     * スペースキー・リターンキーでフォーカスにある元素の詳細を開ける
+     * ESC キーでフォーカスを解除する
      */
     handleKeyDown(event) {
       const key = event.key;
       let nextAtomicNumber = this.focusedAtomicNumber;
+
+      // DataPage がアクティブでない場合のみ、ESC キーでフォーカスを解除する
+      if (key === 'Escape' && !this.isDataPageActive) {
+        this.focusedAtomicNumber = null;
+        event.preventDefault();
+        return;
+      }
+
+      // フォーカスがない状態で方向キーが押された場合
+      if (this.focusedAtomicNumber === null) {
+        if (['ArrowRight', 'ArrowDown'].includes(key)) {
+          // → または ↓ で水素（元素番号 1）にフォーカスする
+          this.focusedAtomicNumber = 1;
+          event.preventDefault();
+          return;
+        } else if (['ArrowLeft', 'ArrowUp'].includes(key)) {
+          // ← または ↑ 矢印でオガネソン（元素番号 118）にフォーカスする
+          this.focusedAtomicNumber = 118;
+          event.preventDefault();
+          return;
+        }
+        return; // フォーカスがない場合は他のキーは処理しない
+      }
 
       switch (key) {
         case 'ArrowRight':
@@ -262,7 +288,7 @@ export default {
           event.preventDefault();
           break;
         case 'ArrowUp': {
-          // ランタノイドやアクチノイドの場合は ↑ でも ← でも前の元素（原子番号-1）に行く
+          // ランタノイドやアクチノイドの場合は ↑ でも ← でも前の元素（原子番号 -1）に行く
           if (this.isLanthanoidOrActinoid(nextAtomicNumber)) {
             nextAtomicNumber--;
             event.preventDefault();
@@ -273,7 +299,7 @@ export default {
           break;
         }
         case 'ArrowDown': {
-          // ランタノイドやアクチノイドの場合は ↓ でも → でも次の元素（原子番号+1）に行く
+          // ランタノイドやアクチノイドの場合は ↓ でも → でも次の元素（原子番号 +1）に行く
           if (this.isLanthanoidOrActinoid(nextAtomicNumber)) {
             nextAtomicNumber++;
             event.preventDefault();

--- a/components/periodic-table/project/periodic_table/PeriodicTable.vue
+++ b/components/periodic-table/project/periodic_table/PeriodicTable.vue
@@ -9,6 +9,7 @@
       height: periodicTableRect.height * periodicTableScale + 'px',
     }"
     @keydown="handleKeyDown"
+    @click="handleBackgroundClick"
     tabindex="0"
     ref="periodicTableSection"
   >
@@ -243,6 +244,19 @@ export default {
       }
 
       return this.focusedAtomicNumber;
+    },
+
+    /**
+     * クリック対象がセクション自体である場合、フォーカスを解除する
+     * @param {Event} event - クリックイベント
+     */
+    handleBackgroundClick(event) {
+      if (
+        event.target === this.$refs.periodicTableSection || 
+        event.target === this.$refs.periodicTable
+      ) {
+        this.focusedAtomicNumber = null;
+      }
     },
 
     /**

--- a/components/periodic-table/project/periodic_table/PeriodicTable.vue
+++ b/components/periodic-table/project/periodic_table/PeriodicTable.vue
@@ -196,6 +196,7 @@ export default {
     }),
     ...mapActions({
       openDataPage: 'element/openDataPage',
+      closeDataPage: 'element/closeDataPage',
     }),
     /**
      * 原子番号がランタノイドまたはアクチノイドかを判定する
@@ -275,9 +276,15 @@ export default {
       const key = event.key;
       let nextAtomicNumber = this.focusedAtomicNumber;
 
-      // DataPage がアクティブでない場合のみ、ESC キーでフォーカスを解除する
-      if (key === 'Escape' && !this.isDataPageActive) {
-        this.updateFocusedAtomicNumber(null);
+      // ESC キーの処理
+      if (key === 'Escape') {
+        if (this.isDataPageActive) {
+          // DataPage がアクティブの場合は閉じるだけでフォーカスは維持する
+          this.closeDataPage();
+        } else {
+          // DataPage がアクティブでない場合はフォーカスを解除する
+          this.updateFocusedAtomicNumber(null);
+        }
         event.preventDefault();
         event.stopPropagation();
         return;
@@ -336,7 +343,13 @@ export default {
         }
         case ' ':
         case 'Enter':
-          this.openDataPage(this.focusedAtomicNumber);
+          if (this.isDataPageActive) {
+            // DataPage がアクティブの場合は閉じる
+            this.closeDataPage();
+          } else {
+            // DataPage がアクティブでない場合は開く
+            this.openDataPage(this.focusedAtomicNumber);
+          }
           event.preventDefault();
           event.stopPropagation();
           return;

--- a/components/periodic-table/project/periodic_table/PeriodicTable.vue
+++ b/components/periodic-table/project/periodic_table/PeriodicTable.vue
@@ -174,7 +174,7 @@ export default {
     // 周期表の幅に対するメディアクエリを作成
     this.createMediaQuery()
     this.checkPeriodicTableOverflow()
-    
+
     // Set initial focus to Hydrogen
     this.$nextTick(() => {
       this.$refs.periodicTableSection.focus();
@@ -190,7 +190,7 @@ export default {
      * 原子番号がランタノイドまたはアクチノイドかを判定する
      */
     isLanthanoidOrActinoid(atomicNumber) {
-      return (atomicNumber >= 57 && atomicNumber <= 71) || 
+      return (atomicNumber >= 57 && atomicNumber <= 71) ||
              (atomicNumber >= 89 && atomicNumber <= 103);
     },
     /**
@@ -228,7 +228,7 @@ export default {
     findNextInGroup(direction) {
       const currentElement = this.elementList.find(e => e.atomicNumber === this.focusedAtomicNumber);
       if (!currentElement) return this.focusedAtomicNumber;
-      
+
       const groupElements = this.groupNavigation[currentElement.group];
       if (!groupElements) return this.focusedAtomicNumber;
 
@@ -236,11 +236,11 @@ export default {
       if (currentIndex === -1) return this.focusedAtomicNumber;
 
       const nextIndex = direction === 'up' ? currentIndex - 1 : currentIndex + 1;
-      
+
       if (nextIndex >= 0 && nextIndex < groupElements.length) {
         return groupElements[nextIndex];
       }
-      
+
       return this.focusedAtomicNumber;
     },
 
@@ -251,7 +251,7 @@ export default {
     handleKeyDown(event) {
       const key = event.key;
       let nextAtomicNumber = this.focusedAtomicNumber;
-      
+
       switch (key) {
         case 'ArrowRight':
           if (nextAtomicNumber < 118) nextAtomicNumber++;
@@ -283,7 +283,7 @@ export default {
           event.preventDefault();
           break;
         }
-        // 
+
         case ' ':
         case 'Enter':
           this.openDataPage(this.focusedAtomicNumber);

--- a/components/periodic-table/project/periodic_table/PeriodicTable.vue
+++ b/components/periodic-table/project/periodic_table/PeriodicTable.vue
@@ -262,7 +262,7 @@ export default {
           event.preventDefault();
           break;
         case 'ArrowUp': {
-          // ランタノイドやアクチノイドの場合は ↑ でも ← でも前の元素（原子番号-1）に行きます
+          // ランタノイドやアクチノイドの場合は ↑ でも ← でも前の元素（原子番号-1）に行く
           if (this.isLanthanoidOrActinoid(nextAtomicNumber)) {
             nextAtomicNumber--;
             event.preventDefault();

--- a/components/periodic-table/project/periodic_table/PeriodicTable.vue
+++ b/components/periodic-table/project/periodic_table/PeriodicTable.vue
@@ -119,7 +119,7 @@ export default {
       periodicTableMQL: null,
       /** フォーカスにある元素の原子番号 */
       focusedAtomicNumber: 1, // Start with Hydrogen
-      // ↑↓で移動する時の原子番号のマップ
+      /** ↑↓で移動する時の原子番号のマップ */
       groupNavigation: {
         1: [1, 3, 11, 19, 37, 55, 87],
         2: [4, 12, 20, 38, 56, 88],

--- a/components/periodic-table/project/periodic_table/PeriodicTable.vue
+++ b/components/periodic-table/project/periodic_table/PeriodicTable.vue
@@ -273,7 +273,7 @@ export default {
           break;
         }
         case 'ArrowDown': {
-          // ランタノイドやアクチノイドの場合は ↓ でも → でも次の元素（原子番号+1）に行きます
+          // ランタノイドやアクチノイドの場合は ↓ でも → でも次の元素（原子番号+1）に行く
           if (this.isLanthanoidOrActinoid(nextAtomicNumber)) {
             nextAtomicNumber++;
             event.preventDefault();

--- a/components/periodic-table/project/periodic_table/PeriodicTable.vue
+++ b/components/periodic-table/project/periodic_table/PeriodicTable.vue
@@ -303,6 +303,7 @@ $animeNameList: 'intoAN' 'intoES' 'intoJA' 'intoEN' 'intoSC' 'intoTW' 'intoHK';
   &__cell-wrapper {
     cursor: pointer;
     transition: transform 1s, opacity, 1s;
+    outline: none;
     @each $cellClass in $cellSymbolList {
       $cellRow: nth($cellRowList, index($cellSymbolList, $cellClass));
       $cellColumn: nth($cellColumnList, index($cellSymbolList, $cellClass));

--- a/components/periodic-table/project/periodic_table/PeriodicTable.vue
+++ b/components/periodic-table/project/periodic_table/PeriodicTable.vue
@@ -175,7 +175,7 @@ export default {
     this.createMediaQuery()
     this.checkPeriodicTableOverflow()
 
-    // Set initial focus to Hydrogen
+    // 最初のフォーカスを水素にする
     this.$nextTick(() => {
       this.$refs.periodicTableSection.focus();
     });

--- a/store/element.js
+++ b/store/element.js
@@ -6,6 +6,7 @@ export const state = () => ({
     isDataPageActive: false,
   })),
   currentDataPage: elementList[1],
+  focusedAtomicNumber: null,
 })
 
 export const getters = {
@@ -25,11 +26,18 @@ export const getters = {
   isDataPageActive: (state) => {
     return state.elementStatusList.some((item) => item.isDataPageActive)
   },
+  // => 現在フォーカスされている元素の原子番号を返す
+  focusedAtomicNumber: (state) => {
+    return state.focusedAtomicNumber
+  },
 }
 
 export const mutations = {
   // 元素のインデクス => 表示するデータページの更新
   activateDataPage(state, index) {
+    // 最初にすべての元素を非アクティブにする
+    state.elementStatusList.forEach((item) => (item.isDataPageActive = false))
+    // 新しい元素をアクティブにする
     state.currentDataPage = state.elementList[index]
     state.elementStatusList[index].isDataPageActive = true
   },
@@ -37,10 +45,14 @@ export const mutations = {
   deactivateDataPage(state) {
     state.elementStatusList.forEach((item) => (item.isDataPageActive = false))
   },
+  // => フォーカスされている元素の原子番号を更新
+  updateFocusedAtomicNumber(state, atomicNumber) {
+    state.focusedAtomicNumber = atomicNumber
+  },
 }
 
 export const actions = {
-  // 原子番号 => データページを表示し、Twitterのwedgets.jsを実行する
+  // 原子番号 => データページを表示し、Twitterのwidgets.jsを実行する
   openDataPage({ state, commit }, atomicNumber) {
     commit(
       'activateDataPage',


### PR DESCRIPTION
- #23 により、ESC で詳細を閉じたあと、元素のボタンにキーボードでナビゲーション可能を示すボーダーが表示されるようになりました

<img width="213" alt="Screenshot 2025-06-01 at 12 20 41 PM-97b10f7d-21bf-4478-89fa-d71dca346072" src="https://github.com/user-attachments/assets/0fbcb4df-b051-403f-a310-cc2d1cc827c1" />

ちょっと醜いのでこの PR で隠しました。

- 詳細画面で次の、または前の元素に行くホットキーを追加しました。F（forward）・N（next）・→方向キーで次の元素に、B（backwards）・P（previous）・←方向キーで前の元素に行きます。